### PR TITLE
Leave room on Disconnect + Close Media Room

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ events.
 We wish to adopt the RSS to a gRPC backend, instead of using socket.io. gRPC is
 better for a potential larger Roomz microservice architecture. Socket.io was
 chosen due to development speed.
+

--- a/README.md
+++ b/README.md
@@ -13,4 +13,3 @@ events.
 We wish to adopt the RSS to a gRPC backend, instead of using socket.io. gRPC is
 better for a potential larger Roomz microservice architecture. Socket.io was
 chosen due to development speed.
-


### PR DESCRIPTION
Lol so many bugs, which I think are all RFE related. Those will be talked about in our next meeting, but for right now, leaving the media room on disconnect and then re-joining works for the following:

* If userN leaves the room and re-joins for N people in the room originally

This means if user2 leaves while user1 and user3 are in the room and re-joins, things break on the RFE side. I could not quickly solve those.

This is at least some progress!